### PR TITLE
`knex` is more a peerDependency than a direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,13 @@
     "url": "https://github.com/holyshared/knex-csv-seeder/issues"
   },
   "homepage": "https://github.com/holyshared/knex-csv-seeder",
+  "peerDependencies": {
+    "knex": "0"
+  },
   "dependencies": {
     "bluebird": "^3.3.5",
     "csv-parse": "~1.1",
     "iconv-lite": "~0.4",
-    "knex": "^0.11.5",
     "lodash": "^4.11.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint": "^2.8.0",
     "espower-coffee": "~1.0",
     "istanbul": "~0.4",
+    "knex": "^0.11.5",
     "mocha": "^2.5.3",
     "mysql": "^2.11.1",
     "power-assert": "^1.4.1"


### PR DESCRIPTION
As `knex-csv-seeder` works with the majority of the `knex` version, we allow all `knex@0.x.x` to match with it.
This is allowing more recent versions of `knex` (like the `0.16` nowadays) to match with it.